### PR TITLE
Drop the stale rerender TODO in clock.test.tsx

### DIFF
--- a/ui/__tests__/clock.test.tsx
+++ b/ui/__tests__/clock.test.tsx
@@ -43,7 +43,9 @@ it("renders correctly and updates over time", () => {
 
   expect(Date.now()).toBe(1577836801000);
 
-  // TODO: ensure the Clock component updates its state and rerenders when time advances
+  // A second on from the snapshot above: the seconds read 01 rather than 00
+  // and the colon has blinked back to visible, so this covers the state
+  // update and rerender on the setInterval tick.
   expect(document.body.firstChild).toMatchInlineSnapshot(`
 <div>
   <div


### PR DESCRIPTION
The TODO in `clock.test.tsx` asks for coverage that the second inline snapshot already provides:

```
// TODO: ensure the Clock component updates its state and rerenders when time advances
```

Commenting out the `setDate(date)` call in `Clock`'s interval fails that assertion — the seconds stay at `00` instead of advancing to `01` — so the rerender is covered.

Replaced it with a note on what the two snapshots differ by, since that is easy to miss: between them only the seconds and the colon's visibility change.

### Base

Stacked on `vitest-migration` (#115) rather than `master`, because the TODO sits a few lines from the `vi.advanceTimersByTime` call that #115 changes. Merge #115 first and this retargets to `master` on its own.

### Verification

`npm test` and `npm run check-compilation` both pass. Comment-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)