### PR TITLE
Bump actions/checkout to v5

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: install
         run: npm ci
@@ -32,7 +32,7 @@ jobs:
     container: mcr.microsoft.com/playwright:v1.62.1-noble
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: install
         run: npm ci


### PR DESCRIPTION
Fixes the "Node.js 20 is deprecated" annotation CI emits for actions/checkout@v4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJbuxrajdXdbikwUzWSyU2